### PR TITLE
[Feature/createAppointment] : 호스트가 미팅 신청을 받을 수 있도록 미팅에 대한 정보를 생성한다.

### DIFF
--- a/src/main/java/com/dev/calendara/apply/Apply.java
+++ b/src/main/java/com/dev/calendara/apply/Apply.java
@@ -8,12 +8,15 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Apply {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,7 +35,7 @@ public class Apply {
     private Appointment appointment;
 
     public void applyAppointment(Appointment appointment) {
-        if (this.appointment != appointment) {
+        if (this.appointment != null) {
             this.appointment.getApplies().remove(this);
         }
         this.appointment = appointment;

--- a/src/main/java/com/dev/calendara/apply/Apply.java
+++ b/src/main/java/com/dev/calendara/apply/Apply.java
@@ -30,4 +30,12 @@ public class Apply {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "appointment_id")
     private Appointment appointment;
+
+    public void applyAppointment(Appointment appointment) {
+        if (this.appointment != appointment) {
+            this.appointment.getApplies().remove(this);
+        }
+        this.appointment = appointment;
+        appointment.getApplies().add(this);
+    }
 }

--- a/src/main/java/com/dev/calendara/appointment/Appointment.java
+++ b/src/main/java/com/dev/calendara/appointment/Appointment.java
@@ -34,7 +34,7 @@ public class Appointment {
     private Long hostId;
 
     @Column(nullable = false)
-    private LocalTime meetingDuration;
+    private int meetingDuration;
 
     @Column(nullable = false)
     private LocalDate meetingStartDate;
@@ -49,7 +49,7 @@ public class Appointment {
     private final List<Apply> applies = new ArrayList<>();
 
     @Builder
-    public Appointment(String title, Long hostId, LocalTime meetingDuration, LocalDate meetingStartDate, LocalDate meetingEndDate) {
+    public Appointment(String title, Long hostId, int meetingDuration, LocalDate meetingStartDate, LocalDate meetingEndDate) {
         this.title = title;
         this.hostId = hostId;
         this.meetingDuration = meetingDuration;

--- a/src/main/java/com/dev/calendara/appointment/Appointment.java
+++ b/src/main/java/com/dev/calendara/appointment/Appointment.java
@@ -2,6 +2,8 @@ package com.dev.calendara.appointment;
 
 import com.dev.calendara.apply.Apply;
 import com.dev.calendara.availabletimes.AvailableTime;
+import com.dev.calendara.common.exception.custom.BusinessException;
+import com.dev.calendara.common.exception.dto.ErrorMessage;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -59,7 +61,7 @@ public class Appointment {
 
     private void validateDateRange(LocalDate meetingStartDate, LocalDate meetingEndDate) {
         if (meetingStartDate.isAfter(meetingEndDate)) {
-            throw new RuntimeException("종료 날짜는 시작 날짜보다 이후이어야 합니다.");
+            throw new BusinessException(ErrorMessage.INVALID_APPOINTMENT_DATE_RANGE);
         }
     }
 

--- a/src/main/java/com/dev/calendara/appointment/Appointment.java
+++ b/src/main/java/com/dev/calendara/appointment/Appointment.java
@@ -3,12 +3,16 @@ package com.dev.calendara.appointment;
 import com.dev.calendara.apply.Apply;
 import com.dev.calendara.availabletimes.AvailableTime;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -17,24 +21,43 @@ import java.util.List;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Appointment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String title;
 
+    @Column(nullable = false)
     private Long hostId;
 
+    @Column(nullable = false)
     private LocalTime meetingDuration;
 
+    @Column(nullable = false)
     private LocalDate meetingStartDate;
 
+    @Column(nullable = false)
     private LocalDate meetingEndDate;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "appointment")
-    private List<AvailableTime> AvailableTimes = new ArrayList<>();
+    private final List<AvailableTime> availableTimes = new ArrayList<>();
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "appointment")
-    private List<Apply> applies = new ArrayList<>();
+    private final List<Apply> applies = new ArrayList<>();
+
+    @Builder
+    public Appointment(String title, Long hostId, LocalTime meetingDuration, LocalDate meetingStartDate, LocalDate meetingEndDate) {
+        this.title = title;
+        this.hostId = hostId;
+        this.meetingDuration = meetingDuration;
+        this.meetingStartDate = meetingStartDate;
+        this.meetingEndDate = meetingEndDate;
+    }
+
+    public void addAvailableTime(AvailableTime availableTime) {
+        availableTimes.add(availableTime);
+    }
 }

--- a/src/main/java/com/dev/calendara/appointment/Appointment.java
+++ b/src/main/java/com/dev/calendara/appointment/Appointment.java
@@ -15,7 +15,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,11 +49,18 @@ public class Appointment {
 
     @Builder
     public Appointment(String title, Long hostId, int meetingDuration, LocalDate meetingStartDate, LocalDate meetingEndDate) {
+        validateDateRange(meetingStartDate, meetingEndDate);
         this.title = title;
         this.hostId = hostId;
         this.meetingDuration = meetingDuration;
         this.meetingStartDate = meetingStartDate;
         this.meetingEndDate = meetingEndDate;
+    }
+
+    private void validateDateRange(LocalDate meetingStartDate, LocalDate meetingEndDate) {
+        if (meetingStartDate.isAfter(meetingEndDate)) {
+            throw new RuntimeException("종료 날짜는 시작 날짜보다 이후이어야 합니다.");
+        }
     }
 
     public void addAvailableTime(AvailableTime availableTime) {

--- a/src/main/java/com/dev/calendara/appointment/controller/AppointmentController.java
+++ b/src/main/java/com/dev/calendara/appointment/controller/AppointmentController.java
@@ -3,6 +3,7 @@ package com.dev.calendara.appointment.controller;
 import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
 import com.dev.calendara.appointment.service.AppointmentService;
 import com.dev.calendara.appointment.service.dto.AppointmentCreateResponse;
+import com.dev.calendara.common.response.dto.BaseResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,7 +17,7 @@ public class AppointmentController {
     private final AppointmentService appointmentService;
 
     @PostMapping("/appointment")
-    public AppointmentCreateResponse createAppointment(@RequestBody AppointmentCreateRequest appointmentCreateRequest) {
-        return appointmentService.createAppointment(appointmentCreateRequest);
+    public BaseResponseDto<AppointmentCreateResponse> createAppointment(@RequestBody AppointmentCreateRequest appointmentCreateRequest) {
+        return BaseResponseDto.ok(appointmentService.createAppointment(appointmentCreateRequest));
     }
 }

--- a/src/main/java/com/dev/calendara/appointment/controller/AppointmentController.java
+++ b/src/main/java/com/dev/calendara/appointment/controller/AppointmentController.java
@@ -1,0 +1,22 @@
+package com.dev.calendara.appointment.controller;
+
+import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
+import com.dev.calendara.appointment.service.AppointmentService;
+import com.dev.calendara.appointment.service.dto.AppointmentCreateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+@RestController
+public class AppointmentController {
+    private final AppointmentService appointmentService;
+
+    @PostMapping("/appointment")
+    public AppointmentCreateResponse createAppointment(@RequestBody AppointmentCreateRequest appointmentCreateRequest) {
+        return appointmentService.createAppointment(appointmentCreateRequest);
+    }
+}

--- a/src/main/java/com/dev/calendara/appointment/controller/dto/AppointmentCreateRequest.java
+++ b/src/main/java/com/dev/calendara/appointment/controller/dto/AppointmentCreateRequest.java
@@ -1,0 +1,18 @@
+package com.dev.calendara.appointment.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record AppointmentCreateRequest(
+        String title,
+        Long hostId,
+        int meetingDuration,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate meetingStartDate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate meetingEndDate,
+        List<AvailableTimeRequest> availableTimes
+) {
+}

--- a/src/main/java/com/dev/calendara/appointment/controller/dto/AvailableTimeRequest.java
+++ b/src/main/java/com/dev/calendara/appointment/controller/dto/AvailableTimeRequest.java
@@ -1,0 +1,12 @@
+package com.dev.calendara.appointment.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record AvailableTimeRequest(
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime availableStartTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime availableEndTime) {
+}

--- a/src/main/java/com/dev/calendara/appointment/repository/AppointmentRepository.java
+++ b/src/main/java/com/dev/calendara/appointment/repository/AppointmentRepository.java
@@ -1,0 +1,7 @@
+package com.dev.calendara.appointment.repository;
+
+import com.dev.calendara.appointment.Appointment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppointmentRepository extends JpaRepository<Appointment, Long> {
+}

--- a/src/main/java/com/dev/calendara/appointment/service/AppointmentService.java
+++ b/src/main/java/com/dev/calendara/appointment/service/AppointmentService.java
@@ -1,0 +1,48 @@
+package com.dev.calendara.appointment.service;
+
+
+import com.dev.calendara.appointment.Appointment;
+import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
+import com.dev.calendara.appointment.repository.AppointmentRepository;
+import com.dev.calendara.appointment.service.dto.AppointmentCreateResponse;
+import com.dev.calendara.availabletimes.AvailableTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class AppointmentService {
+
+    private final AppointmentRepository appointmentRepository;
+
+    public AppointmentCreateResponse createAppointment(AppointmentCreateRequest appointmentCreateRequest) {
+        Appointment appointment = toAppointment(appointmentCreateRequest);
+        setAvailableTimesInAppointment(appointmentCreateRequest, appointment);
+
+        Appointment savedAppointment = appointmentRepository.save(appointment);
+
+        return AppointmentCreateResponse.of(savedAppointment);
+    }
+
+    private Appointment toAppointment(AppointmentCreateRequest appointmentCreateRequest) {
+        return Appointment.builder()
+                .title(appointmentCreateRequest.title())
+                .hostId(appointmentCreateRequest.hostId())
+                .meetingDuration(appointmentCreateRequest.meetingDuration())
+                .meetingStartDate(appointmentCreateRequest.meetingStartDate())
+                .meetingEndDate(appointmentCreateRequest.meetingEndDate())
+                .build();
+    }
+
+    private void setAvailableTimesInAppointment(AppointmentCreateRequest appointmentCreateRequest, Appointment appointment) {
+        appointmentCreateRequest.availableTimes().forEach(availableTimeDto -> {
+            AvailableTime availableTime = AvailableTime.builder()
+                    .availableStartTime(availableTimeDto.availableStartTime())
+                    .availableEndTime(availableTimeDto.availableEndTime())
+                    .build();
+            availableTime.addAvailableTime(appointment);
+        });
+    }
+}

--- a/src/main/java/com/dev/calendara/appointment/service/dto/AppointmentCreateResponse.java
+++ b/src/main/java/com/dev/calendara/appointment/service/dto/AppointmentCreateResponse.java
@@ -1,0 +1,33 @@
+package com.dev.calendara.appointment.service.dto;
+
+import com.dev.calendara.appointment.Appointment;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+public record AppointmentCreateResponse(
+        Long appointmentId,
+        String title,
+        int meetingDuration,
+        LocalDate meetingStartDate,
+        LocalDate meetingEndDate,
+        List<AvailableTimeResponse> availableTimeResponses
+) {
+    public static AppointmentCreateResponse of(Appointment appointment) {
+        return AppointmentCreateResponse.builder()
+                .appointmentId(appointment.getId())
+                .title(appointment.getTitle())
+                .meetingDuration(appointment.getMeetingDuration())
+                .meetingStartDate(appointment.getMeetingStartDate())
+                .meetingEndDate(appointment.getMeetingEndDate())
+                .availableTimeResponses(
+                        appointment.getAvailableTimes().stream()
+                                .map(AvailableTimeResponse::of)
+                                .collect(Collectors.toList())
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/dev/calendara/appointment/service/dto/AvailableTimeResponse.java
+++ b/src/main/java/com/dev/calendara/appointment/service/dto/AvailableTimeResponse.java
@@ -1,0 +1,14 @@
+package com.dev.calendara.appointment.service.dto;
+
+import com.dev.calendara.availabletimes.AvailableTime;
+
+import java.time.LocalDateTime;
+
+public record AvailableTimeResponse(
+        LocalDateTime availableStartTime,
+        LocalDateTime availableEndTime
+) {
+    public static AvailableTimeResponse of(AvailableTime availableTime) {
+        return new AvailableTimeResponse(availableTime.getAvailableStartTime(), availableTime.getAvailableEndTime());
+    }
+}

--- a/src/main/java/com/dev/calendara/appointment/service/dto/AvailableTimeResponse.java
+++ b/src/main/java/com/dev/calendara/appointment/service/dto/AvailableTimeResponse.java
@@ -1,11 +1,14 @@
 package com.dev.calendara.appointment.service.dto;
 
 import com.dev.calendara.availabletimes.AvailableTime;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
 
 public record AvailableTimeResponse(
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
         LocalDateTime availableStartTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
         LocalDateTime availableEndTime
 ) {
     public static AvailableTimeResponse of(AvailableTime availableTime) {

--- a/src/main/java/com/dev/calendara/availabletimes/AvailableTime.java
+++ b/src/main/java/com/dev/calendara/availabletimes/AvailableTime.java
@@ -1,6 +1,8 @@
 package com.dev.calendara.availabletimes;
 
 import com.dev.calendara.appointment.Appointment;
+import com.dev.calendara.common.exception.custom.BusinessException;
+import com.dev.calendara.common.exception.dto.ErrorMessage;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -51,7 +53,7 @@ public class AvailableTime {
         LocalDate meetingStartDate = appointment.getMeetingStartDate();
         LocalDate meetingEndDate = appointment.getMeetingEndDate();
         if (meetingStartDate.atStartOfDay().isAfter(availableStartTime) || meetingEndDate.atTime(23, 59, 59).isBefore(availableEndTime)) {
-            throw new RuntimeException("미팅 가능 시간대는 미팅 기간내에 포함되어야 합니다.");
+            throw new BusinessException(ErrorMessage.INVALID_AVAILABLE_TIME);
         }
     }
 }

--- a/src/main/java/com/dev/calendara/availabletimes/AvailableTime.java
+++ b/src/main/java/com/dev/calendara/availabletimes/AvailableTime.java
@@ -8,12 +8,16 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AvailableTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,8 +31,14 @@ public class AvailableTime {
     @JoinColumn(name = "appointment_id")
     private Appointment appointment;
 
+    @Builder
+    public AvailableTime(LocalDateTime availableStartTime, LocalDateTime availableEndTime) {
+        this.availableStartTime = availableStartTime;
+        this.availableEndTime = availableEndTime;
+    }
+
     public void addAvailableTime(Appointment appointment) {
-        if (this.appointment != appointment) {
+        if (this.appointment != null) {
             this.appointment.getAvailableTimes().remove(this);
         }
         this.appointment = appointment;

--- a/src/main/java/com/dev/calendara/availabletimes/AvailableTime.java
+++ b/src/main/java/com/dev/calendara/availabletimes/AvailableTime.java
@@ -26,4 +26,12 @@ public class AvailableTime {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "appointment_id")
     private Appointment appointment;
+
+    public void addAvailableTime(Appointment appointment) {
+        if (this.appointment != appointment) {
+            this.appointment.getAvailableTimes().remove(this);
+        }
+        this.appointment = appointment;
+        appointment.addAvailableTime(this);
+    }
 }

--- a/src/main/java/com/dev/calendara/availabletimes/AvailableTime.java
+++ b/src/main/java/com/dev/calendara/availabletimes/AvailableTime.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -41,7 +42,16 @@ public class AvailableTime {
         if (this.appointment != null) {
             this.appointment.getAvailableTimes().remove(this);
         }
+        validateAvailableTimes(appointment);
         this.appointment = appointment;
         appointment.addAvailableTime(this);
+    }
+
+    private void validateAvailableTimes(Appointment appointment) {
+        LocalDate meetingStartDate = appointment.getMeetingStartDate();
+        LocalDate meetingEndDate = appointment.getMeetingEndDate();
+        if (meetingStartDate.atStartOfDay().isAfter(availableStartTime) || meetingEndDate.atTime(23, 59, 59).isBefore(availableEndTime)) {
+            throw new RuntimeException("미팅 가능 시간대는 미팅 기간내에 포함되어야 합니다.");
+        }
     }
 }

--- a/src/main/java/com/dev/calendara/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dev/calendara/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.dev.calendara.common.exception;
+
+import com.dev.calendara.common.exception.custom.BusinessException;
+import com.dev.calendara.common.exception.dto.ErrorMessage;
+import com.dev.calendara.common.response.dto.BaseResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public BaseResponseDto<ErrorMessage> businessExceptionHandle(BusinessException e) {
+        log.warn("businessException : ", e);
+        return BaseResponseDto.customError(e.getErrorMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public BaseResponseDto<String> allUncaughtHandle(Exception e) {
+        log.error("allUncaughtHandle : ", e);
+        return BaseResponseDto.error(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
+    }
+
+}

--- a/src/main/java/com/dev/calendara/common/exception/custom/BusinessException.java
+++ b/src/main/java/com/dev/calendara/common/exception/custom/BusinessException.java
@@ -1,0 +1,14 @@
+package com.dev.calendara.common.exception.custom;
+
+import com.dev.calendara.common.exception.dto.ErrorMessage;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorMessage errorMessage;
+
+    public BusinessException(ErrorMessage errorMessage) {
+        super(errorMessage.getPhrase());
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/com/dev/calendara/common/exception/dto/ErrorMessage.java
+++ b/src/main/java/com/dev/calendara/common/exception/dto/ErrorMessage.java
@@ -1,0 +1,21 @@
+package com.dev.calendara.common.exception.dto;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Getter
+public enum ErrorMessage {
+    INVALID_AVAILABLE_TIME(HttpStatus.BAD_REQUEST, "미팅 가능한 시간대는 미팅 기간내에 포함되어야 합니다."),
+    INVALID_APPOINTMENT_DATE_RANGE(HttpStatus.BAD_REQUEST, "회의 신청 기간을 잘못 설정했습니다."),
+    INTERVAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, "요청을 처리하는 과정에서 서버가 예상하지 못한 오류가 발생하였습니다.");
+
+    private final int code;
+    private final String phrase;
+
+    ErrorMessage(HttpStatus status, String phrase) {
+        this.code = status.value();
+        this.phrase = phrase;
+    }
+}

--- a/src/main/java/com/dev/calendara/common/response/dto/BaseResponseDto.java
+++ b/src/main/java/com/dev/calendara/common/response/dto/BaseResponseDto.java
@@ -1,5 +1,7 @@
 package com.dev.calendara.common.response.dto;
 
+import com.dev.calendara.common.exception.dto.ErrorMessage;
+
 import static com.dev.calendara.common.response.dto.ResponseCode.INTERNAL_SERVER_ERROR;
 import static com.dev.calendara.common.response.dto.ResponseCode.SUCCESS;
 
@@ -12,7 +14,11 @@ public record BaseResponseDto<T>(String code, String message, T data) {
         return new BaseResponseDto<>(INTERNAL_SERVER_ERROR.getCode(), INTERNAL_SERVER_ERROR.getMessage(), data);
     }
 
-    public static <T> BaseResponseDto<T> message(T data, String code, String message) {
+    public static <T extends ErrorMessage> BaseResponseDto<T> customError(T data) {
+        return new BaseResponseDto<>(String.valueOf(data.getCode()), data.getPhrase(), data);
+    }
+
+    public static <T> BaseResponseDto<T> message(String code, String message, T data) {
         return new BaseResponseDto<>(code, message, data);
     }
 }

--- a/src/test/java/com/dev/calendara/appointment/controller/AppointmentControllerMockTest.java
+++ b/src/test/java/com/dev/calendara/appointment/controller/AppointmentControllerMockTest.java
@@ -1,0 +1,75 @@
+package com.dev.calendara.appointment.controller;
+
+import com.dev.calendara.appointment.Appointment;
+import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
+import com.dev.calendara.appointment.service.AppointmentService;
+import com.dev.calendara.appointment.service.dto.AppointmentCreateResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+@ActiveProfiles("test")
+class AppointmentControllerMockTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AppointmentService appointmentService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("호스트가 미팅신청 할 수 있도록 생성한다.")
+    @Test
+    void createAppointment() throws Exception {
+        // Given
+        Appointment appointment = new Appointment("test", 3L, 30, LocalDate.of(2023, 7, 22), LocalDate.of(2023, 7, 30));
+        AppointmentCreateResponse createResponse = AppointmentCreateResponse.of(appointment);
+        when(appointmentService.createAppointment(any())).thenReturn(createResponse);
+
+        AppointmentCreateRequest createRequest = new AppointmentCreateRequest("test", 1L, 30, LocalDate.of(2023, 7, 21), LocalDate.of(2023, 7, 30), new ArrayList<>());
+
+        // When Then
+        mockMvc.perform(
+                        post("/api/v1/appointment")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(createRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.appointmentId").value(createResponse.appointmentId()))
+                .andExpect(jsonPath("$.data.title").value(createResponse.title()))
+                .andExpect(jsonPath("$.data.meetingDuration").value(createResponse.meetingDuration()))
+                .andExpect(jsonPath("$.data.meetingStartDate").value(createResponse.meetingStartDate().toString()))
+                .andExpect(jsonPath("$.data.meetingEndDate").value(createResponse.meetingEndDate().toString()))
+                .andExpect(jsonPath("$.data.availableTimeResponses[0].availableStartTime").value(createResponse.availableTimeResponses().get(0).availableStartTime().toString()))
+                .andExpect(jsonPath("$.data.availableTimeResponses[0].availableEndTime").value(createResponse.availableTimeResponses().get(0).availableEndTime().toString()))
+        ;
+    }
+
+
+}

--- a/src/test/java/com/dev/calendara/appointment/controller/AppointmentControllerTest.java
+++ b/src/test/java/com/dev/calendara/appointment/controller/AppointmentControllerTest.java
@@ -1,0 +1,65 @@
+package com.dev.calendara.appointment.controller;
+
+import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
+import com.dev.calendara.appointment.controller.dto.AvailableTimeRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+@ActiveProfiles("test")
+class AppointmentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("호스트가 미팅신청 할 수 있도록 생성한다.")
+    @Test
+    void createAppointment() throws Exception {
+        // Given
+        AvailableTimeRequest availableTimeRequest = new AvailableTimeRequest(LocalDateTime.of(2023, 7, 22, 14, 0), LocalDateTime.of(2023, 7, 22, 22, 0));
+        AppointmentCreateRequest createRequest = new AppointmentCreateRequest("test", 1L, 30, LocalDate.of(2023, 7, 21), LocalDate.of(2023, 7, 30), List.of(availableTimeRequest));
+
+        // When Then
+        mockMvc.perform(
+                        post("/api/v1/appointment")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(createRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.appointmentId").value(1))
+                .andExpect(jsonPath("$.data.title").value(createRequest.title()))
+                .andExpect(jsonPath("$.data.meetingDuration").value(createRequest.meetingDuration()))
+                .andExpect(jsonPath("$.data.meetingStartDate").value(createRequest.meetingStartDate().toString()))
+                .andExpect(jsonPath("$.data.meetingEndDate").value(createRequest.meetingEndDate().toString()))
+                .andExpect(jsonPath("$.data.availableTimeResponses[0].availableStartTime").value(availableTimeRequest.availableStartTime().toString()))
+                .andExpect(jsonPath("$.data.availableTimeResponses[0].availableEndTime").value(availableTimeRequest.availableEndTime().toString()))
+        ;
+    }
+
+
+}

--- a/src/test/java/com/dev/calendara/appointment/service/AppointmentServiceTest.java
+++ b/src/test/java/com/dev/calendara/appointment/service/AppointmentServiceTest.java
@@ -3,6 +3,7 @@ package com.dev.calendara.appointment.service;
 import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
 import com.dev.calendara.appointment.controller.dto.AvailableTimeRequest;
 import com.dev.calendara.appointment.service.dto.AppointmentCreateResponse;
+import com.dev.calendara.common.exception.custom.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -106,8 +107,8 @@ class AppointmentServiceTest {
 
         // When Then
         assertThatThrownBy(() -> appointmentService.createAppointment(createRequest))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("종료 날짜는 시작 날짜보다 이후이어야 합니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("회의 신청 기간을 잘못 설정했습니다.");
     }
 
     @Test
@@ -143,7 +144,7 @@ class AppointmentServiceTest {
 
         // When Then
         assertThatThrownBy(() -> appointmentService.createAppointment(createRequest))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("미팅 가능 시간대는 미팅 기간내에 포함되어야 합니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("미팅 가능한 시간대는 미팅 기간내에 포함되어야 합니다.");
     }
 }

--- a/src/test/java/com/dev/calendara/appointment/service/AppointmentServiceTest.java
+++ b/src/test/java/com/dev/calendara/appointment/service/AppointmentServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -18,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 
+@ActiveProfiles("test")
 @Transactional
 @SpringBootTest
 class AppointmentServiceTest {

--- a/src/test/java/com/dev/calendara/appointment/service/AppointmentServiceTest.java
+++ b/src/test/java/com/dev/calendara/appointment/service/AppointmentServiceTest.java
@@ -1,0 +1,81 @@
+package com.dev.calendara.appointment.service;
+
+import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
+import com.dev.calendara.appointment.controller.dto.AvailableTimeRequest;
+import com.dev.calendara.appointment.service.dto.AppointmentCreateResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+@Transactional
+@SpringBootTest
+class AppointmentServiceTest {
+
+    @Autowired
+    private AppointmentService appointmentService;
+
+    @Test
+    @DisplayName("약속 신청에 대한 정보(제목, 신청 가능기간 및 시간, 미팅 지속시간)를 받아 약속 신청을 생성한다.")
+    void createAppointment() {
+        // Given
+        LocalDateTime startTime1 = LocalDateTime.of(2023, 7, 21, 14, 0);
+        LocalDateTime endTime1 = LocalDateTime.of(2023, 7, 21, 18, 30);
+        AvailableTimeRequest availableTime1 = new AvailableTimeRequest(
+                startTime1,
+                endTime1
+        );
+        LocalDateTime startTime2 = LocalDateTime.of(2023, 7, 22, 14, 0);
+        LocalDateTime endTime2 = LocalDateTime.of(2023, 7, 22, 22, 30);
+        AvailableTimeRequest availableTime2 = new AvailableTimeRequest(
+                startTime2,
+                endTime2
+        );
+        LocalDateTime startTime3 = LocalDateTime.of(2023, 7, 25, 9, 0);
+        LocalDateTime endTime3 = LocalDateTime.of(2023, 7, 25, 20, 30);
+        AvailableTimeRequest availableTime3 = new AvailableTimeRequest(
+                startTime3,
+                endTime3
+        );
+
+        LocalDate meetingStartDate = LocalDate.of(2023, 7, 21);
+        LocalDate meetingEndDate = LocalDate.of(2023, 7, 25);
+        AppointmentCreateRequest createRequest = new AppointmentCreateRequest(
+                "test title",
+                1L,
+                30,
+                meetingStartDate,
+                meetingEndDate,
+                List.of(
+                        availableTime1,
+                        availableTime2,
+                        availableTime3
+                )
+        );
+
+        // When
+        AppointmentCreateResponse appointmentCreateResponse = appointmentService.createAppointment(createRequest);
+
+        // Then
+        assertThat(appointmentCreateResponse.appointmentId()).isNotNull();
+        assertThat(appointmentCreateResponse.title()).isEqualTo("test title");
+        assertThat(appointmentCreateResponse.meetingDuration()).isEqualTo(30);
+        assertThat(appointmentCreateResponse.meetingStartDate()).isEqualTo(meetingStartDate);
+        assertThat(appointmentCreateResponse.meetingEndDate()).isEqualTo(meetingEndDate);
+        assertThat(appointmentCreateResponse.availableTimeResponses()).hasSize(3)
+                .extracting("availableStartTime", "availableEndTime")
+                .containsExactlyInAnyOrder(
+                        tuple(startTime1, endTime1),
+                        tuple(startTime2, endTime2),
+                        tuple(startTime3, endTime3)
+                );
+    }
+}


### PR DESCRIPTION
- 호스트가 미팅 신청을 받을 수 있도록 미팅에 대한 정보를 생성하는 API 구현했습니다.
- 리턴값으로 BaseResponseDto 사용할 수 있도록 생성했습니다.
- 비즈니스 익셉션에 대한 처리를 할 수 있도록 RestControllerAdvice 를 구현했습니다.
- 양방향 매핑 도메인 간에 연관관계 편의 메서드가 빠져있어서 구현했습니다.

미팅에 대한 정보를 생성말고 다른 내용이 들어가서 내용이 많아졌는데 혹시 궁금한거 있으면 코멘트 부탁드립니다!

closed #3 