### PR TITLE
[Feature/getAppointment] : 호스트가 만든 미팅 정보를 가져오는 API 구현

### DIFF
--- a/src/main/java/com/dev/calendara/appointment/controller/AppointmentController.java
+++ b/src/main/java/com/dev/calendara/appointment/controller/AppointmentController.java
@@ -3,11 +3,14 @@ package com.dev.calendara.appointment.controller;
 import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
 import com.dev.calendara.appointment.service.AppointmentService;
 import com.dev.calendara.appointment.service.dto.AppointmentCreateResponse;
+import com.dev.calendara.appointment.service.dto.AppointmentForm;
 import com.dev.calendara.common.response.dto.BaseResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -19,5 +22,10 @@ public class AppointmentController {
     @PostMapping("/appointment")
     public BaseResponseDto<AppointmentCreateResponse> createAppointment(@RequestBody AppointmentCreateRequest appointmentCreateRequest) {
         return BaseResponseDto.ok(appointmentService.createAppointment(appointmentCreateRequest));
+    }
+
+    @GetMapping("/appointment")
+    public BaseResponseDto<AppointmentForm> getAppointment(@RequestParam Long appointmentId) {
+        return BaseResponseDto.ok(appointmentService.getAppointment(appointmentId));
     }
 }

--- a/src/main/java/com/dev/calendara/appointment/service/AppointmentService.java
+++ b/src/main/java/com/dev/calendara/appointment/service/AppointmentService.java
@@ -5,10 +5,16 @@ import com.dev.calendara.appointment.Appointment;
 import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
 import com.dev.calendara.appointment.repository.AppointmentRepository;
 import com.dev.calendara.appointment.service.dto.AppointmentCreateResponse;
+import com.dev.calendara.appointment.service.dto.AppointmentForm;
+import com.dev.calendara.appointment.service.dto.AvailableTimeDto;
 import com.dev.calendara.availabletimes.AvailableTime;
+import com.dev.calendara.common.exception.custom.BusinessException;
+import com.dev.calendara.common.exception.dto.ErrorMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Transactional
 @RequiredArgsConstructor
@@ -44,5 +50,23 @@ public class AppointmentService {
                     .build();
             availableTime.addAvailableTime(appointment);
         });
+    }
+
+
+    @Transactional(readOnly = true)
+    public AppointmentForm getAppointment(Long appointmentId) {
+        Appointment appointment = appointmentRepository.findById(appointmentId).orElseThrow(() -> new BusinessException(ErrorMessage.NOT_FOUND_APPOINTMENT_FORM));
+        List<AvailableTime> availableTimes = appointment.getAvailableTimes();
+        return new AppointmentForm(
+                appointment.getId(),
+                appointment.getTitle(),
+                appointment.getMeetingStartDate(),
+                appointment.getMeetingEndDate(),
+                appointment.getMeetingDuration(),
+                availableTimes.stream().map(
+                                availableTime ->
+                                        new AvailableTimeDto(availableTime.getAvailableStartTime(),
+                                                availableTime.getAvailableEndTime()))
+                        .toList());
     }
 }

--- a/src/main/java/com/dev/calendara/appointment/service/dto/AppointmentForm.java
+++ b/src/main/java/com/dev/calendara/appointment/service/dto/AppointmentForm.java
@@ -1,0 +1,14 @@
+package com.dev.calendara.appointment.service.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record AppointmentForm(
+        Long appointmentId,
+        String title,
+        LocalDate startDate,
+        LocalDate endDate,
+        int meetingDuration,
+        List<AvailableTimeDto> availableTimes
+) {
+}

--- a/src/main/java/com/dev/calendara/appointment/service/dto/AvailableTimeDto.java
+++ b/src/main/java/com/dev/calendara/appointment/service/dto/AvailableTimeDto.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record AvailableTimeDto(
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
         LocalDateTime availableStartTime,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
         LocalDateTime availableEndTime
 ) {
 }

--- a/src/main/java/com/dev/calendara/appointment/service/dto/AvailableTimeDto.java
+++ b/src/main/java/com/dev/calendara/appointment/service/dto/AvailableTimeDto.java
@@ -1,17 +1,13 @@
 package com.dev.calendara.appointment.service.dto;
 
-import com.dev.calendara.availabletimes.AvailableTime;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
 
-public record AvailableTimeResponse(
+public record AvailableTimeDto(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime availableStartTime,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         LocalDateTime availableEndTime
 ) {
-    public static AvailableTimeResponse of(AvailableTime availableTime) {
-        return new AvailableTimeResponse(availableTime.getAvailableStartTime(), availableTime.getAvailableEndTime());
-    }
 }

--- a/src/main/java/com/dev/calendara/appointment/service/dto/AvailableTimeResponse.java
+++ b/src/main/java/com/dev/calendara/appointment/service/dto/AvailableTimeResponse.java
@@ -6,9 +6,9 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record AvailableTimeResponse(
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
         LocalDateTime availableStartTime,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
         LocalDateTime availableEndTime
 ) {
     public static AvailableTimeResponse of(AvailableTime availableTime) {

--- a/src/main/java/com/dev/calendara/common/exception/dto/ErrorMessage.java
+++ b/src/main/java/com/dev/calendara/common/exception/dto/ErrorMessage.java
@@ -9,6 +9,7 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 public enum ErrorMessage {
     INVALID_AVAILABLE_TIME(HttpStatus.BAD_REQUEST, "미팅 가능한 시간대는 미팅 기간내에 포함되어야 합니다."),
     INVALID_APPOINTMENT_DATE_RANGE(HttpStatus.BAD_REQUEST, "회의 신청 기간을 잘못 설정했습니다."),
+    NOT_FOUND_APPOINTMENT_FORM(HttpStatus.BAD_REQUEST, "회의 신청 정보를 찾을 수 없습니다."),
     INTERVAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, "요청을 처리하는 과정에서 서버가 예상하지 못한 오류가 발생하였습니다.");
 
     private final int code;

--- a/src/test/java/com/dev/calendara/appointment/controller/AppointmentControllerMockTest.java
+++ b/src/test/java/com/dev/calendara/appointment/controller/AppointmentControllerMockTest.java
@@ -4,19 +4,20 @@ import com.dev.calendara.appointment.Appointment;
 import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
 import com.dev.calendara.appointment.service.AppointmentService;
 import com.dev.calendara.appointment.service.dto.AppointmentCreateResponse;
+import com.dev.calendara.availabletimes.AvailableTime;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -26,9 +27,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Transactional
 @AutoConfigureMockMvc
-@SpringBootTest
+@WebMvcTest(AppointmentController.class)
 @ActiveProfiles("test")
 class AppointmentControllerMockTest {
 
@@ -46,6 +46,8 @@ class AppointmentControllerMockTest {
     void createAppointment() throws Exception {
         // Given
         Appointment appointment = new Appointment("test", 3L, 30, LocalDate.of(2023, 7, 22), LocalDate.of(2023, 7, 30));
+        AvailableTime availableTime = new AvailableTime(LocalDateTime.of(2023, 7, 24, 10, 0), LocalDateTime.of(2023, 7, 24, 12, 0));
+        availableTime.addAvailableTime(appointment);
         AppointmentCreateResponse createResponse = AppointmentCreateResponse.of(appointment);
         when(appointmentService.createAppointment(any())).thenReturn(createResponse);
 

--- a/src/test/java/com/dev/calendara/appointment/controller/AppointmentControllerTest.java
+++ b/src/test/java/com/dev/calendara/appointment/controller/AppointmentControllerTest.java
@@ -1,7 +1,10 @@
 package com.dev.calendara.appointment.controller;
 
+import com.dev.calendara.appointment.Appointment;
 import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
 import com.dev.calendara.appointment.controller.dto.AvailableTimeRequest;
+import com.dev.calendara.appointment.repository.AppointmentRepository;
+import com.dev.calendara.availabletimes.AvailableTime;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +20,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -33,6 +37,9 @@ class AppointmentControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Autowired
+    private AppointmentRepository appointmentRepository;
 
     @DisplayName("호스트가 미팅신청 할 수 있도록 생성한다.")
     @Test
@@ -61,5 +68,33 @@ class AppointmentControllerTest {
         ;
     }
 
+    @DisplayName("게스트가 미팅신청에 대한 정보를 가져온다.")
+    @Test
+    void getAppointment() throws Exception {
+        // Given
+        Appointment appointment = new Appointment("test", 3L, 30, LocalDate.of(2023, 7, 22), LocalDate.of(2023, 7, 30));
+        AvailableTime availableTime = new AvailableTime(LocalDateTime.of(2023, 7, 24, 10, 0), LocalDateTime.of(2023, 7, 24, 12, 0));
+        availableTime.addAvailableTime(appointment);
+        Appointment savedAppointment = appointmentRepository.save(appointment);
+
+        // When Then
+        mockMvc.perform(
+                        get("/api/v1/appointment")
+                                .param("appointmentId", savedAppointment.getId().toString())
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.appointmentId").value(savedAppointment.getId()))
+                .andExpect(jsonPath("$.data.title").value(savedAppointment.getTitle()))
+                .andExpect(jsonPath("$.data.meetingDuration").value(savedAppointment.getMeetingDuration()))
+                .andExpect(jsonPath("$.data.startDate").value(savedAppointment.getMeetingStartDate().toString()))
+                .andExpect(jsonPath("$.data.endDate").value(savedAppointment.getMeetingEndDate().toString()))
+                .andExpect(jsonPath("$.data.availableTimes[0].availableStartTime").value(availableTime.getAvailableStartTime().toString()))
+                .andExpect(jsonPath("$.data.availableTimes[0].availableEndTime").value(availableTime.getAvailableEndTime().toString()))
+        ;
+    }
 
 }

--- a/src/test/java/com/dev/calendara/appointment/service/AppointmentServiceTest.java
+++ b/src/test/java/com/dev/calendara/appointment/service/AppointmentServiceTest.java
@@ -1,9 +1,14 @@
 package com.dev.calendara.appointment.service;
 
+import com.dev.calendara.appointment.Appointment;
 import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
 import com.dev.calendara.appointment.controller.dto.AvailableTimeRequest;
+import com.dev.calendara.appointment.repository.AppointmentRepository;
 import com.dev.calendara.appointment.service.dto.AppointmentCreateResponse;
+import com.dev.calendara.appointment.service.dto.AppointmentForm;
+import com.dev.calendara.availabletimes.AvailableTime;
 import com.dev.calendara.common.exception.custom.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +23,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @ActiveProfiles("test")
 @Transactional
@@ -27,60 +33,47 @@ class AppointmentServiceTest {
     @Autowired
     private AppointmentService appointmentService;
 
+    @Autowired
+    private AppointmentRepository appointmentRepository;
+
+    @BeforeEach
+    void setUp() {
+        Appointment appointment = new Appointment("test", 3L, 30, LocalDate.of(2023, 7, 22), LocalDate.of(2023, 7, 30));
+        AvailableTime availableTime = new AvailableTime(LocalDateTime.of(2023, 7, 24, 10, 0), LocalDateTime.of(2023, 7, 24, 12, 0));
+        availableTime.addAvailableTime(appointment);
+        appointmentRepository.save(appointment);
+    }
+
     @Test
     @DisplayName("약속 신청에 대한 정보(제목, 신청 가능기간 및 시간, 미팅 지속시간)를 받아 약속 신청을 생성한다.")
     void createAppointment() {
         // Given
         LocalDateTime startTime1 = LocalDateTime.of(2023, 7, 21, 0, 0);
         LocalDateTime endTime1 = LocalDateTime.of(2023, 7, 21, 1, 30);
-        AvailableTimeRequest availableTime1 = new AvailableTimeRequest(
-                startTime1,
-                endTime1
-        );
+        AvailableTimeRequest availableTime1 = new AvailableTimeRequest(startTime1, endTime1);
         LocalDateTime startTime2 = LocalDateTime.of(2023, 7, 22, 14, 0);
         LocalDateTime endTime2 = LocalDateTime.of(2023, 7, 22, 22, 30);
-        AvailableTimeRequest availableTime2 = new AvailableTimeRequest(
-                startTime2,
-                endTime2
-        );
+        AvailableTimeRequest availableTime2 = new AvailableTimeRequest(startTime2, endTime2);
         LocalDateTime startTime3 = LocalDateTime.of(2023, 7, 25, 23, 0);
         LocalDateTime endTime3 = LocalDateTime.of(2023, 7, 25, 23, 50);
-        AvailableTimeRequest availableTime3 = new AvailableTimeRequest(
-                startTime3,
-                endTime3
-        );
+        AvailableTimeRequest availableTime3 = new AvailableTimeRequest(startTime3, endTime3);
 
         LocalDate meetingStartDate = LocalDate.of(2023, 7, 21);
         LocalDate meetingEndDate = LocalDate.of(2023, 7, 25);
-        AppointmentCreateRequest createRequest = new AppointmentCreateRequest(
-                "test title",
-                1L,
-                30,
-                meetingStartDate,
-                meetingEndDate,
-                List.of(
-                        availableTime1,
-                        availableTime2,
-                        availableTime3
-                )
-        );
+        AppointmentCreateRequest createRequest = new AppointmentCreateRequest("test title", 1L, 30, meetingStartDate, meetingEndDate, List.of(availableTime1, availableTime2, availableTime3));
 
         // When
         AppointmentCreateResponse appointmentCreateResponse = appointmentService.createAppointment(createRequest);
 
         // Then
-        assertThat(appointmentCreateResponse.appointmentId()).isNotNull();
-        assertThat(appointmentCreateResponse.title()).isEqualTo("test title");
-        assertThat(appointmentCreateResponse.meetingDuration()).isEqualTo(30);
-        assertThat(appointmentCreateResponse.meetingStartDate()).isEqualTo(meetingStartDate);
-        assertThat(appointmentCreateResponse.meetingEndDate()).isEqualTo(meetingEndDate);
-        assertThat(appointmentCreateResponse.availableTimeResponses()).hasSize(3)
-                .extracting("availableStartTime", "availableEndTime")
-                .containsExactlyInAnyOrder(
-                        tuple(startTime1, endTime1),
-                        tuple(startTime2, endTime2),
-                        tuple(startTime3, endTime3)
-                );
+        assertAll(
+                () -> assertThat(appointmentCreateResponse.appointmentId()).isNotNull(),
+                () -> assertThat(appointmentCreateResponse.title()).isEqualTo("test title"),
+                () -> assertThat(appointmentCreateResponse.meetingDuration()).isEqualTo(30),
+                () -> assertThat(appointmentCreateResponse.meetingStartDate()).isEqualTo(meetingStartDate),
+                () -> assertThat(appointmentCreateResponse.meetingEndDate()).isEqualTo(meetingEndDate),
+                () -> assertThat(appointmentCreateResponse.availableTimeResponses()).hasSize(3).extracting("availableStartTime", "availableEndTime").containsExactlyInAnyOrder(tuple(startTime1, endTime1), tuple(startTime2, endTime2), tuple(startTime3, endTime3))
+        );
     }
 
     @Test
@@ -89,28 +82,14 @@ class AppointmentServiceTest {
         // Given
         LocalDateTime startTime1 = LocalDateTime.of(2023, 7, 21, 14, 0);
         LocalDateTime endTime1 = LocalDateTime.of(2023, 7, 21, 18, 30);
-        AvailableTimeRequest availableTime1 = new AvailableTimeRequest(
-                startTime1,
-                endTime1
-        );
+        AvailableTimeRequest availableTime1 = new AvailableTimeRequest(startTime1, endTime1);
 
         LocalDate meetingStartDate = LocalDate.of(2023, 7, 30);
         LocalDate meetingEndDate = LocalDate.of(2023, 7, 20);
-        AppointmentCreateRequest createRequest = new AppointmentCreateRequest(
-                "test title",
-                1L,
-                30,
-                meetingStartDate,
-                meetingEndDate,
-                List.of(
-                        availableTime1
-                )
-        );
+        AppointmentCreateRequest createRequest = new AppointmentCreateRequest("test title", 1L, 30, meetingStartDate, meetingEndDate, List.of(availableTime1));
 
         // When Then
-        assertThatThrownBy(() -> appointmentService.createAppointment(createRequest))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("회의 신청 기간을 잘못 설정했습니다.");
+        assertThatThrownBy(() -> appointmentService.createAppointment(createRequest)).isInstanceOf(BusinessException.class).hasMessage("회의 신청 기간을 잘못 설정했습니다.");
     }
 
     @Test
@@ -119,34 +98,33 @@ class AppointmentServiceTest {
         // Given
         LocalDateTime startTime1 = LocalDateTime.of(2023, 7, 21, 14, 0);
         LocalDateTime endTime1 = LocalDateTime.of(2023, 7, 21, 18, 30);
-        AvailableTimeRequest availableTime1 = new AvailableTimeRequest(
-                startTime1,
-                endTime1
-        );
+        AvailableTimeRequest availableTime1 = new AvailableTimeRequest(startTime1, endTime1);
         LocalDateTime startTime2 = LocalDateTime.of(2023, 7, 19, 14, 0);
         LocalDateTime endTime2 = LocalDateTime.of(2023, 7, 19, 22, 30);
-        AvailableTimeRequest impossibleTime = new AvailableTimeRequest(
-                startTime2,
-                endTime2
-        );
+        AvailableTimeRequest impossibleTime = new AvailableTimeRequest(startTime2, endTime2);
 
         LocalDate meetingStartDate = LocalDate.of(2023, 7, 20);
         LocalDate meetingEndDate = LocalDate.of(2023, 7, 30);
-        AppointmentCreateRequest createRequest = new AppointmentCreateRequest(
-                "test title",
-                1L,
-                30,
-                meetingStartDate,
-                meetingEndDate,
-                List.of(
-                        availableTime1,
-                        impossibleTime
-                )
-        );
+        AppointmentCreateRequest createRequest = new AppointmentCreateRequest("test title", 1L, 30, meetingStartDate, meetingEndDate, List.of(availableTime1, impossibleTime));
 
         // When Then
-        assertThatThrownBy(() -> appointmentService.createAppointment(createRequest))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("미팅 가능한 시간대는 미팅 기간내에 포함되어야 합니다.");
+        assertThatThrownBy(() -> appointmentService.createAppointment(createRequest)).isInstanceOf(BusinessException.class).hasMessage("미팅 가능한 시간대는 미팅 기간내에 포함되어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("약속 신청에 대한 정보를 게스트가 확인할 수 있어야 한다.")
+    void getAppointment() {
+        // Given
+
+        // When
+        AppointmentForm appointmentForm = appointmentService.getAppointment(1L);
+        // Then
+        assertAll(
+                () -> assertThat(appointmentForm.appointmentId()).isEqualTo(1L),
+                () -> assertThat(appointmentForm.title()).isEqualTo("test"),
+                () -> assertThat(appointmentForm.startDate()).isEqualTo(LocalDate.of(2023, 7, 22)),
+                () -> assertThat(appointmentForm.endDate()).isEqualTo(LocalDate.of(2023, 7, 30)),
+                () -> assertThat(appointmentForm.meetingDuration()).isEqualTo(30),
+                () -> assertThat(appointmentForm.availableTimes().size()).isOne());
     }
 }


### PR DESCRIPTION
- 게스트가 미팅 신청을 하기전에 호스트가 만든 미팅 신청 양식에 대한 정보를 확인한 후 신청할 수 있기 때문에 먼저 구현했습니다.
- 양식은 미팅 정보 아이디, 제목, 미팅 기간의 시작날짜, 미팅 기간의 종료날짜, 미팅 지속시간, 미팅 가능 시간대를 나타냅니다.

closed #7 