### PR TITLE
[Feature/applyAppointment] : 게스트가 미팅에 대해서 신청하는 API 구현

### DIFF
--- a/src/main/java/com/dev/calendara/apply/Apply.java
+++ b/src/main/java/com/dev/calendara/apply/Apply.java
@@ -1,14 +1,9 @@
 package com.dev.calendara.apply;
 
 import com.dev.calendara.appointment.Appointment;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,7 +21,7 @@ public class Apply {
 
     private LocalDateTime applyEndTime;
 
-    private Long userId;
+    private Long memberId;
 
     private String confirmYn;
 
@@ -34,11 +29,20 @@ public class Apply {
     @JoinColumn(name = "appointment_id")
     private Appointment appointment;
 
-    public void applyAppointment(Appointment appointment) {
+    @Builder
+    public Apply(LocalDateTime applyStartTime, LocalDateTime applyEndTime, Long memberId, String confirmYn, Appointment appointment) {
+        this.applyStartTime = applyStartTime;
+        this.applyEndTime = applyEndTime;
+        this.memberId = memberId;
+        this.confirmYn = confirmYn;
+        addApply(appointment);
+    }
+
+    public void addApply(Appointment appointment) {
         if (this.appointment != null) {
             this.appointment.getApplies().remove(this);
         }
         this.appointment = appointment;
-        appointment.getApplies().add(this);
+        appointment.addApply(this);
     }
 }

--- a/src/main/java/com/dev/calendara/apply/controller/ApplyController.java
+++ b/src/main/java/com/dev/calendara/apply/controller/ApplyController.java
@@ -1,0 +1,24 @@
+package com.dev.calendara.apply.controller;
+
+import com.dev.calendara.apply.controller.dto.ApplyCreateRequest;
+import com.dev.calendara.apply.service.ApplyService;
+import com.dev.calendara.apply.service.dto.ApplyCreateServiceResponse;
+import com.dev.calendara.common.response.dto.BaseResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+@RestController
+public class ApplyController {
+
+    private final ApplyService applyService;
+
+    @PostMapping("/apply")
+    public BaseResponseDto<ApplyCreateServiceResponse> applyAppointment(@RequestBody ApplyCreateRequest applyCreateRequest) {
+        return BaseResponseDto.ok(applyService.applyAppointment(applyCreateRequest.of()));
+    }
+}

--- a/src/main/java/com/dev/calendara/apply/controller/dto/ApplyCreateRequest.java
+++ b/src/main/java/com/dev/calendara/apply/controller/dto/ApplyCreateRequest.java
@@ -1,0 +1,17 @@
+package com.dev.calendara.apply.controller.dto;
+
+import com.dev.calendara.apply.service.dto.ApplyCreateServiceRequest;
+
+import java.time.LocalDateTime;
+
+public record ApplyCreateRequest(
+        Long appointmentId,
+        LocalDateTime meetingStartTime,
+        LocalDateTime meetingEndTime,
+        Long memberId
+) {
+
+    public ApplyCreateServiceRequest of() {
+        return new ApplyCreateServiceRequest(appointmentId, meetingStartTime, meetingEndTime, memberId);
+    }
+}

--- a/src/main/java/com/dev/calendara/apply/domain/Apply.java
+++ b/src/main/java/com/dev/calendara/apply/domain/Apply.java
@@ -1,5 +1,6 @@
-package com.dev.calendara.apply;
+package com.dev.calendara.apply.domain;
 
+import com.dev.calendara.apply.domain.enumeration.ApplyStatus;
 import com.dev.calendara.appointment.Appointment;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -25,18 +26,23 @@ public class Apply {
 
     private String confirmYn;
 
+    @Enumerated(EnumType.STRING)
+    private ApplyStatus applyStatus;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "appointment_id")
     private Appointment appointment;
 
     @Builder
-    public Apply(LocalDateTime applyStartTime, LocalDateTime applyEndTime, Long memberId, String confirmYn, Appointment appointment) {
+    public Apply(LocalDateTime applyStartTime, LocalDateTime applyEndTime, Long memberId, String confirmYn, Appointment appointment, ApplyStatus applyStatus) {
         this.applyStartTime = applyStartTime;
         this.applyEndTime = applyEndTime;
         this.memberId = memberId;
         this.confirmYn = confirmYn;
+        this.applyStatus = applyStatus;
         addApply(appointment);
     }
+
 
     public void addApply(Appointment appointment) {
         if (this.appointment != null) {

--- a/src/main/java/com/dev/calendara/apply/domain/Apply.java
+++ b/src/main/java/com/dev/calendara/apply/domain/Apply.java
@@ -24,8 +24,6 @@ public class Apply {
 
     private Long memberId;
 
-    private String confirmYn;
-
     @Enumerated(EnumType.STRING)
     private ApplyStatus applyStatus;
 
@@ -34,11 +32,10 @@ public class Apply {
     private Appointment appointment;
 
     @Builder
-    public Apply(LocalDateTime applyStartTime, LocalDateTime applyEndTime, Long memberId, String confirmYn, Appointment appointment, ApplyStatus applyStatus) {
+    public Apply(LocalDateTime applyStartTime, LocalDateTime applyEndTime, Long memberId, Appointment appointment, ApplyStatus applyStatus) {
         this.applyStartTime = applyStartTime;
         this.applyEndTime = applyEndTime;
         this.memberId = memberId;
-        this.confirmYn = confirmYn;
         this.applyStatus = applyStatus;
         addApply(appointment);
     }

--- a/src/main/java/com/dev/calendara/apply/domain/enumeration/ApplyStatus.java
+++ b/src/main/java/com/dev/calendara/apply/domain/enumeration/ApplyStatus.java
@@ -1,0 +1,17 @@
+package com.dev.calendara.apply.domain.enumeration;
+
+public enum ApplyStatus {
+    WAIT("미팅 신청 후 대기상태"),
+    APPROVE("미팅 신청 승인"),
+    REJECT("미팅 신청 반려");
+
+    private final String description;
+
+    ApplyStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/dev/calendara/apply/repository/ApplyRepository.java
+++ b/src/main/java/com/dev/calendara/apply/repository/ApplyRepository.java
@@ -1,0 +1,7 @@
+package com.dev.calendara.apply.repository;
+
+import com.dev.calendara.apply.Apply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplyRepository extends JpaRepository<Apply, Long> {
+}

--- a/src/main/java/com/dev/calendara/apply/repository/ApplyRepository.java
+++ b/src/main/java/com/dev/calendara/apply/repository/ApplyRepository.java
@@ -1,6 +1,6 @@
 package com.dev.calendara.apply.repository;
 
-import com.dev.calendara.apply.Apply;
+import com.dev.calendara.apply.domain.Apply;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ApplyRepository extends JpaRepository<Apply, Long> {

--- a/src/main/java/com/dev/calendara/apply/service/ApplyService.java
+++ b/src/main/java/com/dev/calendara/apply/service/ApplyService.java
@@ -1,6 +1,7 @@
 package com.dev.calendara.apply.service;
 
-import com.dev.calendara.apply.Apply;
+import com.dev.calendara.apply.domain.Apply;
+import com.dev.calendara.apply.domain.enumeration.ApplyStatus;
 import com.dev.calendara.apply.repository.ApplyRepository;
 import com.dev.calendara.apply.service.dto.ApplyCreateServiceRequest;
 import com.dev.calendara.apply.service.dto.ApplyCreateServiceResponse;
@@ -39,6 +40,7 @@ public class ApplyService {
                 .applyEndTime(applyCreateServiceDto.meetingEndTime())
                 .applyStartTime(applyCreateServiceDto.meetingStartTime())
                 .confirmYn("N")
+                .applyStatus(ApplyStatus.WAIT)
                 .build();
         Apply savedApply = applyRepository.save(apply);
 

--- a/src/main/java/com/dev/calendara/apply/service/ApplyService.java
+++ b/src/main/java/com/dev/calendara/apply/service/ApplyService.java
@@ -39,7 +39,6 @@ public class ApplyService {
                 .memberId(applyCreateServiceDto.memberId())
                 .applyEndTime(applyCreateServiceDto.meetingEndTime())
                 .applyStartTime(applyCreateServiceDto.meetingStartTime())
-                .confirmYn("N")
                 .applyStatus(ApplyStatus.WAIT)
                 .build();
         Apply savedApply = applyRepository.save(apply);

--- a/src/main/java/com/dev/calendara/apply/service/ApplyService.java
+++ b/src/main/java/com/dev/calendara/apply/service/ApplyService.java
@@ -29,7 +29,7 @@ public class ApplyService {
         Appointment appointment = appointmentRepository.findById(applyCreateServiceDto.appointmentId()).orElseThrow(() -> new BusinessException(ErrorMessage.NOT_FOUND_APPOINTMENT));
         LocalDateTime startTime = applyCreateServiceDto.meetingStartTime();
         LocalDateTime endTime = applyCreateServiceDto.meetingEndTime();
-        
+
         verifyApplyTime(startTime, endTime, appointment);
         verifyAvailableTime(appointment, startTime, endTime);
 
@@ -55,7 +55,7 @@ public class ApplyService {
         });
 
         if (!containAvailableTimeResult) {
-            throw new BusinessException(ErrorMessage.INVALID_AVAILABLE_TIME);
+            throw new BusinessException(ErrorMessage.INVALID_APPLY_TIME);
         }
     }
 

--- a/src/main/java/com/dev/calendara/apply/service/ApplyService.java
+++ b/src/main/java/com/dev/calendara/apply/service/ApplyService.java
@@ -1,0 +1,70 @@
+package com.dev.calendara.apply.service;
+
+import com.dev.calendara.apply.Apply;
+import com.dev.calendara.apply.repository.ApplyRepository;
+import com.dev.calendara.apply.service.dto.ApplyCreateServiceRequest;
+import com.dev.calendara.apply.service.dto.ApplyCreateServiceResponse;
+import com.dev.calendara.appointment.Appointment;
+import com.dev.calendara.appointment.repository.AppointmentRepository;
+import com.dev.calendara.availabletimes.AvailableTime;
+import com.dev.calendara.common.exception.custom.BusinessException;
+import com.dev.calendara.common.exception.dto.ErrorMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ApplyService {
+
+    private final ApplyRepository applyRepository;
+    private final AppointmentRepository appointmentRepository;
+
+    public ApplyCreateServiceResponse applyAppointment(ApplyCreateServiceRequest applyCreateServiceDto) {
+        Appointment appointment = appointmentRepository.findById(applyCreateServiceDto.appointmentId()).orElseThrow(() -> new BusinessException(ErrorMessage.NOT_FOUND_APPOINTMENT));
+        LocalDateTime startTime = applyCreateServiceDto.meetingStartTime();
+        LocalDateTime endTime = applyCreateServiceDto.meetingEndTime();
+        
+        verifyApplyTime(startTime, endTime, appointment);
+        verifyAvailableTime(appointment, startTime, endTime);
+
+        Apply apply = Apply.builder()
+                .appointment(appointment)
+                .memberId(applyCreateServiceDto.memberId())
+                .applyEndTime(applyCreateServiceDto.meetingEndTime())
+                .applyStartTime(applyCreateServiceDto.meetingStartTime())
+                .confirmYn("N")
+                .build();
+        Apply savedApply = applyRepository.save(apply);
+
+        return ApplyCreateServiceResponse.of(savedApply);
+    }
+
+    private void verifyAvailableTime(Appointment appointment, LocalDateTime startTime, LocalDateTime endTime) {
+        List<AvailableTime> availableTimes = appointment.getAvailableTimes();
+        boolean containAvailableTimeResult = availableTimes.stream().anyMatch(availableTime -> {
+            LocalDateTime availableStartTime = availableTime.getAvailableStartTime();
+            LocalDateTime availableEndTime = availableTime.getAvailableEndTime();
+            return (startTime.equals(availableStartTime) || startTime.isAfter(availableStartTime)) &&
+                    (endTime.equals(availableEndTime) || endTime.isBefore(availableEndTime));
+        });
+
+        if (!containAvailableTimeResult) {
+            throw new BusinessException(ErrorMessage.INVALID_AVAILABLE_TIME);
+        }
+    }
+
+    private void verifyApplyTime(LocalDateTime startTime, LocalDateTime endTime, Appointment appointment) {
+        Duration duration = Duration.between(startTime, endTime);
+        long applyMeetingDuration = duration.getSeconds();
+        long appointmentMeetingDuration = Duration.ofMinutes(appointment.getMeetingDuration()).getSeconds();
+        if (appointmentMeetingDuration != applyMeetingDuration) {
+            throw new BusinessException(ErrorMessage.INVALID_MEETING_DURATION_TIME);
+        }
+    }
+}

--- a/src/main/java/com/dev/calendara/apply/service/dto/ApplyCreateServiceRequest.java
+++ b/src/main/java/com/dev/calendara/apply/service/dto/ApplyCreateServiceRequest.java
@@ -1,0 +1,11 @@
+package com.dev.calendara.apply.service.dto;
+
+import java.time.LocalDateTime;
+
+public record ApplyCreateServiceRequest(
+        Long appointmentId,
+        LocalDateTime meetingStartTime,
+        LocalDateTime meetingEndTime,
+        Long memberId
+) {
+}

--- a/src/main/java/com/dev/calendara/apply/service/dto/ApplyCreateServiceResponse.java
+++ b/src/main/java/com/dev/calendara/apply/service/dto/ApplyCreateServiceResponse.java
@@ -1,6 +1,6 @@
 package com.dev.calendara.apply.service.dto;
 
-import com.dev.calendara.apply.Apply;
+import com.dev.calendara.apply.domain.Apply;
 
 public record ApplyCreateServiceResponse(
         Long applyId

--- a/src/main/java/com/dev/calendara/apply/service/dto/ApplyCreateServiceResponse.java
+++ b/src/main/java/com/dev/calendara/apply/service/dto/ApplyCreateServiceResponse.java
@@ -1,0 +1,11 @@
+package com.dev.calendara.apply.service.dto;
+
+import com.dev.calendara.apply.Apply;
+
+public record ApplyCreateServiceResponse(
+        Long applyId
+) {
+    public static ApplyCreateServiceResponse of(Apply savedApply) {
+        return new ApplyCreateServiceResponse(savedApply.getId());
+    }
+}

--- a/src/main/java/com/dev/calendara/appointment/Appointment.java
+++ b/src/main/java/com/dev/calendara/appointment/Appointment.java
@@ -68,4 +68,8 @@ public class Appointment {
     public void addAvailableTime(AvailableTime availableTime) {
         availableTimes.add(availableTime);
     }
+
+    public void addApply(Apply apply) {
+        applies.add(apply);
+    }
 }

--- a/src/main/java/com/dev/calendara/appointment/Appointment.java
+++ b/src/main/java/com/dev/calendara/appointment/Appointment.java
@@ -1,16 +1,10 @@
 package com.dev.calendara.appointment;
 
-import com.dev.calendara.apply.Apply;
+import com.dev.calendara.apply.domain.Apply;
 import com.dev.calendara.availabletimes.AvailableTime;
 import com.dev.calendara.common.exception.custom.BusinessException;
 import com.dev.calendara.common.exception.dto.ErrorMessage;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/dev/calendara/common/exception/dto/ErrorMessage.java
+++ b/src/main/java/com/dev/calendara/common/exception/dto/ErrorMessage.java
@@ -9,7 +9,11 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 public enum ErrorMessage {
     INVALID_AVAILABLE_TIME(HttpStatus.BAD_REQUEST, "미팅 가능한 시간대는 미팅 기간내에 포함되어야 합니다."),
     INVALID_APPOINTMENT_DATE_RANGE(HttpStatus.BAD_REQUEST, "회의 신청 기간을 잘못 설정했습니다."),
-    INTERVAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, "요청을 처리하는 과정에서 서버가 예상하지 못한 오류가 발생하였습니다.");
+    INVALID_MEETING_DURATION_TIME(HttpStatus.BAD_REQUEST, "미팅 지속 시간에 맞게 요청 해야 합니다."),
+    NOT_FOUND_APPOINTMENT(HttpStatus.NOT_FOUND, "신청하고자 하는 미팅 정보를 찾을 수 없습니다."),
+    INTERVAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, "요청을 처리하는 과정에서 서버가 예상하지 못한 오류가 발생하였습니다."),
+    INVALID_APPLY_TIME(HttpStatus.BAD_REQUEST, "미팅 신청 시간은 미팅 신청 가능 시간내에 포함되어야 합니다."),
+    ;
 
     private final int code;
     private final String phrase;

--- a/src/test/java/com/dev/calendara/apply/controller/ApplyControllerTest.java
+++ b/src/test/java/com/dev/calendara/apply/controller/ApplyControllerTest.java
@@ -1,0 +1,62 @@
+package com.dev.calendara.apply.controller;
+
+import com.dev.calendara.apply.controller.dto.ApplyCreateRequest;
+import com.dev.calendara.apply.service.ApplyService;
+import com.dev.calendara.apply.service.dto.ApplyCreateServiceResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+@ActiveProfiles("test")
+class ApplyControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ApplyService applyService;
+
+    @Test
+    @DisplayName("게스트가 미팅 신청을 한다.")
+    void applyAppointment() throws Exception {
+        // Given
+        ApplyCreateRequest applyCreateRequest = new ApplyCreateRequest(1L, LocalDateTime.of(2023, 8, 3, 12, 0), LocalDateTime.of(2023, 8, 3, 12, 30), 1L);
+        ApplyCreateServiceResponse applyCreateServiceResponse = new ApplyCreateServiceResponse(1L);
+        when(applyService.applyAppointment(applyCreateRequest.of())).thenReturn(applyCreateServiceResponse);
+
+        // When Then
+        mockMvc.perform(
+                        post("/api/v1/apply")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(applyCreateRequest))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.applyId").value(1))
+        ;
+    }
+}

--- a/src/test/java/com/dev/calendara/apply/service/ApplyServiceTest.java
+++ b/src/test/java/com/dev/calendara/apply/service/ApplyServiceTest.java
@@ -34,7 +34,7 @@ class ApplyServiceTest {
     @MockBean
     private AppointmentRepository appointmentRepository;
 
-    @DisplayName("사용자가 미팅 정보를 작성 후 신청할 수 있다.")
+    @DisplayName("게스트가 미팅 정보를 작성 후 신청할 수 있다.")
     @Test
     void applyAppointment() {
         // given
@@ -64,7 +64,7 @@ class ApplyServiceTest {
         assertThat(applyCreateServiceResponse.applyId()).isNotNull();
     }
 
-    @DisplayName("사용자가 미팅 신청 시 호스트가 정한 미팅 지속 시간에 맞지 않게 신청한 경우 예외 발생 시킨다.")
+    @DisplayName("게스트가 미팅 신청 시 호스트가 정한 미팅 지속 시간에 맞지 않게 신청한 경우 예외 발생 시킨다.")
     @Test
     void applyAppointment2() {
         // given
@@ -97,7 +97,7 @@ class ApplyServiceTest {
                 .hasMessage(ErrorMessage.INVALID_MEETING_DURATION_TIME.getPhrase());
     }
 
-    @DisplayName("사용자가 미팅 신청한 기간이 미팅 가능 시간이 아닌 경우 예외 발생 시킨다.")
+    @DisplayName("게스트가 미팅 신청한 기간이 미팅 가능 시간이 아닌 경우 예외 발생 시킨다.")
     @Test
     void applyAppointment3() {
         // given

--- a/src/test/java/com/dev/calendara/apply/service/ApplyServiceTest.java
+++ b/src/test/java/com/dev/calendara/apply/service/ApplyServiceTest.java
@@ -1,13 +1,27 @@
 package com.dev.calendara.apply.service;
 
-import com.dev.calendara.apply.repository.ApplyRepository;
+import com.dev.calendara.apply.service.dto.ApplyCreateServiceRequest;
+import com.dev.calendara.apply.service.dto.ApplyCreateServiceResponse;
+import com.dev.calendara.appointment.Appointment;
 import com.dev.calendara.appointment.repository.AppointmentRepository;
+import com.dev.calendara.availabletimes.AvailableTime;
+import com.dev.calendara.common.exception.custom.BusinessException;
+import com.dev.calendara.common.exception.dto.ErrorMessage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
 @ActiveProfiles("test")
 @Transactional
@@ -15,14 +29,104 @@ import org.springframework.transaction.annotation.Transactional;
 class ApplyServiceTest {
 
     @Autowired
-    private ApplyRepository applyRepository;
+    private ApplyService applyService;
 
-    @Autowired
+    @MockBean
     private AppointmentRepository appointmentRepository;
 
-    @DisplayName("사용자가 미팅 정보를 작성 후 신청한다.")
+    @DisplayName("사용자가 미팅 정보를 작성 후 신청할 수 있다.")
     @Test
     void applyAppointment() {
-        
+        // given
+        Appointment appointment = Appointment.builder()
+                .hostId(1L)
+                .meetingDuration(30)
+                .meetingStartDate(LocalDate.of(2023, 8, 1))
+                .meetingEndDate(LocalDate.of(2023, 8, 10))
+                .title("test")
+                .build();
+        AvailableTime availableTime1 = AvailableTime.builder()
+                .availableStartTime(LocalDateTime.of(2023, 8, 2, 18, 0))
+                .availableEndTime(LocalDateTime.of(2023, 8, 2, 23, 0))
+                .build();
+        AvailableTime availableTime2 = AvailableTime.builder()
+                .availableStartTime(LocalDateTime.of(2023, 8, 3, 18, 0))
+                .availableEndTime(LocalDateTime.of(2023, 8, 3, 23, 0))
+                .build();
+        availableTime1.addAvailableTime(appointment);
+        availableTime2.addAvailableTime(appointment);
+        when(appointmentRepository.findById(1L)).thenReturn(Optional.of(appointment));
+
+        // when
+        ApplyCreateServiceResponse applyCreateServiceResponse = applyService.applyAppointment(new ApplyCreateServiceRequest(1L, LocalDateTime.of(2023, 8, 2, 18, 0), LocalDateTime.of(2023, 8, 2, 18, 30), 1L));
+
+        // then
+        assertThat(applyCreateServiceResponse.applyId()).isNotNull();
+    }
+
+    @DisplayName("사용자가 미팅 신청 시 호스트가 정한 미팅 지속 시간에 맞지 않게 신청한 경우 예외 발생 시킨다.")
+    @Test
+    void applyAppointment2() {
+        // given
+        int meetingDuration = 30;
+        Appointment appointment = Appointment.builder()
+                .hostId(1L)
+                .meetingDuration(meetingDuration)
+                .meetingStartDate(LocalDate.of(2023, 8, 1))
+                .meetingEndDate(LocalDate.of(2023, 8, 10))
+                .title("test")
+                .build();
+        AvailableTime availableTime1 = AvailableTime.builder()
+                .availableStartTime(LocalDateTime.of(2023, 8, 2, 18, 0))
+                .availableEndTime(LocalDateTime.of(2023, 8, 2, 23, 0))
+                .build();
+        AvailableTime availableTime2 = AvailableTime.builder()
+                .availableStartTime(LocalDateTime.of(2023, 8, 3, 18, 0))
+                .availableEndTime(LocalDateTime.of(2023, 8, 3, 23, 0))
+                .build();
+        availableTime1.addAvailableTime(appointment);
+        availableTime2.addAvailableTime(appointment);
+        when(appointmentRepository.findById(1L)).thenReturn(Optional.of(appointment));
+
+        // when
+        // then
+        assertThatThrownBy(
+                () -> applyService.applyAppointment(new ApplyCreateServiceRequest(1L, LocalDateTime.of(2023, 8, 2, 18, 0), LocalDateTime.of(2023, 8, 2, 19, 0), 1L)),
+                "호스트가 정한 미팅 지속 시간은 30분인데 1시간 신청한 경우")
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorMessage.INVALID_MEETING_DURATION_TIME.getPhrase());
+    }
+
+    @DisplayName("사용자가 미팅 신청한 기간이 미팅 가능 시간이 아닌 경우 예외 발생 시킨다.")
+    @Test
+    void applyAppointment3() {
+        // given
+        int meetingDuration = 30;
+        Appointment appointment = Appointment.builder()
+                .hostId(1L)
+                .meetingDuration(meetingDuration)
+                .meetingStartDate(LocalDate.of(2023, 8, 1))
+                .meetingEndDate(LocalDate.of(2023, 8, 10))
+                .title("test")
+                .build();
+        AvailableTime availableTime1 = AvailableTime.builder()
+                .availableStartTime(LocalDateTime.of(2023, 8, 2, 18, 0))
+                .availableEndTime(LocalDateTime.of(2023, 8, 2, 23, 0))
+                .build();
+        AvailableTime availableTime2 = AvailableTime.builder()
+                .availableStartTime(LocalDateTime.of(2023, 8, 3, 18, 0))
+                .availableEndTime(LocalDateTime.of(2023, 8, 3, 23, 0))
+                .build();
+        availableTime1.addAvailableTime(appointment);
+        availableTime2.addAvailableTime(appointment);
+        when(appointmentRepository.findById(1L)).thenReturn(Optional.of(appointment));
+
+        // when
+        // then
+        assertThatThrownBy(
+                () -> applyService.applyAppointment(new ApplyCreateServiceRequest(1L, LocalDateTime.of(2023, 8, 2, 17, 30), LocalDateTime.of(2023, 8, 2, 18, 0), 1L)),
+                "미팅 신청 시간이 미팅 가능 기간 내에 포함되지 않는 경우")
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorMessage.INVALID_APPLY_TIME.getPhrase());
     }
 }

--- a/src/test/java/com/dev/calendara/apply/service/ApplyServiceTest.java
+++ b/src/test/java/com/dev/calendara/apply/service/ApplyServiceTest.java
@@ -1,0 +1,28 @@
+package com.dev.calendara.apply.service;
+
+import com.dev.calendara.apply.repository.ApplyRepository;
+import com.dev.calendara.appointment.repository.AppointmentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest
+class ApplyServiceTest {
+
+    @Autowired
+    private ApplyRepository applyRepository;
+
+    @Autowired
+    private AppointmentRepository appointmentRepository;
+
+    @DisplayName("사용자가 미팅 정보를 작성 후 신청한다.")
+    @Test
+    void applyAppointment() {
+        
+    }
+}

--- a/src/test/java/com/dev/calendara/appointment/controller/AppointmentControllerMockTest.java
+++ b/src/test/java/com/dev/calendara/appointment/controller/AppointmentControllerMockTest.java
@@ -4,6 +4,7 @@ import com.dev.calendara.appointment.Appointment;
 import com.dev.calendara.appointment.controller.dto.AppointmentCreateRequest;
 import com.dev.calendara.appointment.service.AppointmentService;
 import com.dev.calendara.appointment.service.dto.AppointmentCreateResponse;
+import com.dev.calendara.availabletimes.AvailableTime;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -46,6 +48,8 @@ class AppointmentControllerMockTest {
     void createAppointment() throws Exception {
         // Given
         Appointment appointment = new Appointment("test", 3L, 30, LocalDate.of(2023, 7, 22), LocalDate.of(2023, 7, 30));
+        AvailableTime availableTime = new AvailableTime(LocalDateTime.of(2023, 7, 23, 12, 0), LocalDateTime.of(2023, 7, 23, 19, 0));
+        availableTime.addAvailableTime(appointment);
         AppointmentCreateResponse createResponse = AppointmentCreateResponse.of(appointment);
         when(appointmentService.createAppointment(any())).thenReturn(createResponse);
 


### PR DESCRIPTION
- 호스트가 만든 미팅 양식에 대해서 게스트는 미팅을 신청할 수 있다.
- 게스트가 미팅 신청 할때, 호스트가 정한 미팅지속 시간 만큼의 시간만 신청할 수 있고 아니면 예외 발생시키도록 했습니다.
- 게스트가 미팅 신청 할때, 호스트가 정한 미팅 가능시간대 내에서 신청해야만 하고 아니면 예외발생시키도록 했습니다.
- 미팅 신청 상태에 대해서 원래 confirmYn 으로 이야기 했었는데 Enum 값으로 관리하는것이 더 명확해 보이고 좋을거 같아서 변경했습니다.

closed #7 